### PR TITLE
Update for Swift 5.2, NIO 2.15, NIO-SSL 2.7.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,30 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "Core",
-        "repositoryURL": "https://github.com/vapor/core.git",
-        "state": {
-          "branch": null,
-          "revision": "10d33362a47fab03a067e78fb0791341d9c634fa",
-          "version": "3.9.3"
-        }
-      },
-      {
-        "package": "Service",
-        "repositoryURL": "https://github.com/vapor/service.git",
-        "state": {
-          "branch": null,
-          "revision": "fa5b5de62bd68bcde9a69933f31319e46c7275fb",
-          "version": "1.0.2"
-        }
-      },
-      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "ba7970fe396e8198b84c6c1b44b38a1d4e2eb6bd",
-          "version": "1.14.1"
+          "revision": "a27a07719ca785bcaca019a5b9fe1814b981b4a2",
+          "version": "2.15.0"
         }
       },
       {
@@ -33,26 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "0f3999f3e3c359cc74480c292644c3419e44a12f",
-          "version": "1.4.0"
-        }
-      },
-      {
-        "package": "swift-nio-ssl-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-ssl-support.git",
-        "state": {
-          "branch": null,
-          "revision": "c02eec4e0e6d351cd092938cf44195a8e669f555",
-          "version": "1.0.0"
-        }
-      },
-      {
-        "package": "swift-nio-zlib-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
-        "state": {
-          "branch": null,
-          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
-          "version": "1.0.0"
+          "revision": "ae213938e151964aa691f0e902462fbe06baeeb6",
+          "version": "2.7.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -10,33 +10,40 @@ let package = Package(
         .library(
             name: "SwiftSMTP",
             targets: ["SwiftSMTP"]),
-        .library(
-            name: "SwiftSMTPVapor",
-            targets: ["SwiftSMTPVapor"]),
+//        .library(
+//            name: "SwiftSMTPVapor",
+//            targets: ["SwiftSMTPVapor"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-nio.git", from: "1.14.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "1.4.0"),
-        .package(url: "https://github.com/vapor/service.git", from: "1.0.2"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.15.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.7.1"),
+        //.package(url: "https://github.com/vapor/service.git", from: "1.0.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "SwiftSMTP",
-            dependencies: ["NIO", "NIOOpenSSL", "NIOConcurrencyHelpers"]),
-        .target(
-            name: "SwiftSMTPVapor",
-            dependencies: ["SwiftSMTP", "Service"]),
+            dependencies: [
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOSSL", package: "swift-nio-ssl"),
+                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+            ]),
+//        .target(
+//            name: "SwiftSMTPVapor",
+//            dependencies: ["SwiftSMTP", "Service"]),
         .target(
             name: "SwiftSMTPCLI",
-            dependencies: ["SwiftSMTP", "NIO"]),
+            dependencies: [
+                "SwiftSMTP",
+                .product(name: "NIO", package: "swift-nio"),
+            ]),
         .testTarget(
             name: "SwiftSMTPTests",
             dependencies: ["SwiftSMTP"]),
-        .testTarget(
-            name: "SwiftSMTPVaporTests",
-            dependencies: ["SwiftSMTPVapor"]),
+//        .testTarget(
+//            name: "SwiftSMTPVaporTests",
+//            dependencies: ["SwiftSMTPVapor"]),
     ]
 )

--- a/Sources/SwiftSMTP/Mailer.swift
+++ b/Sources/SwiftSMTP/Mailer.swift
@@ -125,7 +125,7 @@ public final class Mailer {
     }
 
     public func send(email: Email) -> EventLoopFuture<Void> {
-        let promise = group.next().makePromise(of: Void.self) // could this be .makePromise()
+        let promise = group.next().makePromise(of: Void.self)
         pushEmail(ScheduledEmail(email: email, promise: promise))
         scheduleMailDelivery()
         return promise.futureResult

--- a/Sources/SwiftSMTP/Mailer.swift
+++ b/Sources/SwiftSMTP/Mailer.swift
@@ -86,9 +86,9 @@ public final class Mailer {
             .channelInitializer { [configuration, logTransmissions] in
                 do {
                     var handlers: [ChannelHandler] = [
-                        LineBasedFrameDecoder(),
+                        ByteToMessageHandler(LineBasedFrameDecoder()),
                         SMTPResponseDecoder(),
-                        SMTPRequestEncoder(),
+                        MessageToByteHandler(SMTPRequestEncoder()),
                         SMTPHandler(configuration: configuration, email: email.email, allDonePromise: email.promise),
                     ]
                     if logTransmissions {

--- a/Sources/SwiftSMTP/NIO Channel Handlers/LineBasedFrameDecoder.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/LineBasedFrameDecoder.swift
@@ -1,6 +1,6 @@
 import NIO
 
-final class LineBasedFrameDecoder: ByteToMessageDecoder, ChannelHandler {
+final class LineBasedFrameDecoder: ByteToMessageDecoder, ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
 
@@ -11,6 +11,14 @@ final class LineBasedFrameDecoder: ByteToMessageDecoder, ChannelHandler {
     private var handledLeftovers = false
 
     init() {}
+    
+    
+    // Both ByteToMessageDeocoder & ChannelInboundHandler define default implementation, causing ambiguity
+    // Redefining it here seems to be required to remove ambiguity for the compiler
+    @inlinable
+    func wrapInboundOut(_ value: InboundOut) -> NIOAny {
+        return NIOAny(value)
+    }
 
     func decode(context ctx: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
         if let frame = try findNextFrame(buffer: &buffer) {

--- a/Sources/SwiftSMTP/NIO Channel Handlers/LineBasedFrameDecoder.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/LineBasedFrameDecoder.swift
@@ -47,15 +47,15 @@ final class LineBasedFrameDecoder: ByteToMessageDecoder, ChannelInboundHandler {
         return nil
     }
 
-    func handlerRemoved(ctx: ChannelHandlerContext) {
-        handleLeftOverBytes(ctx: ctx)
+    func handlerRemoved(context ctx: ChannelHandlerContext) {
+        handleLeftOverBytes(context: ctx)
     }
 
-    func channelInactive(ctx: ChannelHandlerContext) {
-        handleLeftOverBytes(ctx: ctx)
+    func channelInactive(context ctx: ChannelHandlerContext) {
+        handleLeftOverBytes(context: ctx)
     }
 
-    private func handleLeftOverBytes(ctx: ChannelHandlerContext) {
+    private func handleLeftOverBytes(context ctx: ChannelHandlerContext) {
         if let buffer = cumulationBuffer, buffer.readableBytes > 0 && !handledLeftovers {
             handledLeftovers = true
             ctx.fireErrorCaught(LeftOverBytesError(leftOverBytes: buffer))

--- a/Sources/SwiftSMTP/NIO Channel Handlers/LineBasedFrameDecoder.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/LineBasedFrameDecoder.swift
@@ -1,6 +1,6 @@
 import NIO
 
-final class LineBasedFrameDecoder: ByteToMessageDecoder {
+final class LineBasedFrameDecoder: ByteToMessageDecoder, ChannelHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
 
@@ -12,7 +12,7 @@ final class LineBasedFrameDecoder: ByteToMessageDecoder {
 
     init() {}
 
-    func decode(ctx: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
+    func decode(context ctx: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
         if let frame = try findNextFrame(buffer: &buffer) {
             ctx.fireChannelRead(wrapInboundOut(frame))
             return .continue

--- a/Sources/SwiftSMTP/NIO Channel Handlers/LogDuplexHandler.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/LogDuplexHandler.swift
@@ -7,12 +7,12 @@ final class LogDuplexHandler: ChannelDuplexHandler {
     typealias OutboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer
 
-    func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+    func channelRead(context ctx: ChannelHandlerContext, data: NIOAny) {
         print("☁️ \(String(decoding: unwrapInboundIn(data).readableBytesView, as: UTF8.self))")
         ctx.fireChannelRead(data)
     }
 
-    func write(ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+    func write(context ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         print("💻 \(String(decoding: unwrapOutboundIn(data).readableBytesView, as: UTF8.self))")
         ctx.write(data, promise: promise)
     }

--- a/Sources/SwiftSMTP/NIO Channel Handlers/SMTPHandler.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/SMTPHandler.swift
@@ -99,7 +99,7 @@ final class SMTPHandler: ChannelInboundHandler {
             send(command: .quit)
             state = .quitSent
         case .quitSent:
-            let promise = ctx.eventLoop.makePromise(of: Void.self) // would .makePromise() work here?
+            let promise = ctx.eventLoop.makePromise(of: Void.self)
             promise.futureResult.flatMapErrorThrowing {
                 guard !self.shouldIgnore(error: $0) else { return }
                 throw $0

--- a/Sources/SwiftSMTP/NIO Channel Handlers/SMTPHandler.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/SMTPHandler.swift
@@ -43,7 +43,7 @@ final class SMTPHandler: ChannelInboundHandler {
         self.allDonePromise = allDonePromise
     }
 
-    func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+    func channelRead(context ctx: ChannelHandlerContext, data: NIOAny) {
         guard unwrapInboundIn(data).verify(failing: allDonePromise) else { return }
 
         func send(command: SMTPRequest) {
@@ -120,7 +120,7 @@ final class SMTPHandler: ChannelInboundHandler {
         }
     }
 
-    func errorCaught(ctx: ChannelHandlerContext, error: Error) {
+    func errorCaught(context ctx: ChannelHandlerContext, error: Error) {
         guard !shouldIgnore(error: error) else { return }
         allDonePromise.fail(error)
     }

--- a/Sources/SwiftSMTP/NIO Channel Handlers/SMTPRequestEncoder.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/SMTPRequestEncoder.swift
@@ -9,11 +9,7 @@ fileprivate extension DateFormatter {
     }()
 }
 
-final class SMTPRequestEncoder: MessageToByteEncoder, ChannelHandler {
-    func encode(data: SMTPRequest, out: inout ByteBuffer) throws {
-        assertionFailure()
-    }
-    
+final class SMTPRequestEncoder: MessageToByteEncoder, ChannelOutboundHandler {
     typealias OutboundIn = SMTPRequest
 
     private func createMultipartBoundary() -> String {
@@ -32,7 +28,7 @@ final class SMTPRequestEncoder: MessageToByteEncoder, ChannelHandler {
         }.joined(separator: "\r\n--\(boundary)\r\n")
     }
 
-    func encode(ctx: ChannelHandlerContext, data: SMTPRequest, out: inout ByteBuffer) throws {
+    func encode(data: SMTPRequest, out: inout ByteBuffer) throws {
         switch data {
         case .sayHello(serverName: let server):
             out.writeString("HELO \(server)")

--- a/Sources/SwiftSMTP/NIO Channel Handlers/SMTPRequestEncoder.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/SMTPRequestEncoder.swift
@@ -9,7 +9,11 @@ fileprivate extension DateFormatter {
     }()
 }
 
-final class SMTPRequestEncoder: MessageToByteEncoder {
+final class SMTPRequestEncoder: MessageToByteEncoder, ChannelHandler {
+    func encode(data: SMTPRequest, out: inout ByteBuffer) throws {
+        assertionFailure()
+    }
+    
     typealias OutboundIn = SMTPRequest
 
     private func createMultipartBoundary() -> String {
@@ -31,34 +35,34 @@ final class SMTPRequestEncoder: MessageToByteEncoder {
     func encode(ctx: ChannelHandlerContext, data: SMTPRequest, out: inout ByteBuffer) throws {
         switch data {
         case .sayHello(serverName: let server):
-            out.write(string: "HELO \(server)")
+            out.writeString("HELO \(server)")
         case .startTLS:
-            out.write(string: "STARTTLS")
+            out.writeString("STARTTLS")
         case .beginAuthentication:
-            out.write(string: "AUTH LOGIN")
+            out.writeString("AUTH LOGIN")
         case .authUser(let user):
-            out.write(bytes: Data(user.utf8).base64EncodedData())
+            out.writeBytes(Data(user.utf8).base64EncodedData())
         case .authPassword(let password):
-            out.write(bytes: Data(password.utf8).base64EncodedData())
+            out.writeBytes(Data(password.utf8).base64EncodedData())
         case .mailFrom(let from):
-            out.write(string: "MAIL FROM:<\(from)>")
+            out.writeString("MAIL FROM:<\(from)>")
         case .recipient(let rcpt):
-            out.write(string: "RCPT TO:<\(rcpt)>")
+            out.writeString("RCPT TO:<\(rcpt)>")
         case .data:
-            out.write(string: "DATA")
+            out.writeString("DATA")
         case .transferData(let email):
             let date = Date()
-            out.write(string: "From: \(email.sender.asMIME)\r\n")
-            out.write(string: "To: \(email.recipients.map { $0.asMIME }.joined(separator: ", "))\r\n")
+            out.writeString("From: \(email.sender.asMIME)\r\n")
+            out.writeString("To: \(email.recipients.map { $0.asMIME }.joined(separator: ", "))\r\n")
             if let replyTo = email.replyTo {
-                out.write(string: "Reply-to: \(replyTo.asMIME)\r\n")
+            out.writeString("Reply-to: \(replyTo.asMIME)\r\n")
             }
             if !email.cc.isEmpty {
-                out.write(string: "Cc: \(email.cc.map { $0.asMIME }.joined(separator: ", "))\r\n")
+            out.writeString("Cc: \(email.cc.map { $0.asMIME }.joined(separator: ", "))\r\n")
             }
-            out.write(string: "Date: \(DateFormatter.smtp.string(from: date))\r\n")
-            out.write(string: "Message-ID: <\(date.timeIntervalSince1970)\(email.sender.emailAddress.drop { $0 != "@" })>\r\n")
-            out.write(string: "Subject: \(email.subject)\r\n")
+            out.writeString("Date: \(DateFormatter.smtp.string(from: date))\r\n")
+            out.writeString("Message-ID: <\(date.timeIntervalSince1970)\(email.sender.emailAddress.drop { $0 != "@" })>\r\n")
+            out.writeString("Subject: \(email.subject)\r\n")
 
             let contentType: String
             let bodyAndAttachments: String
@@ -122,13 +126,13 @@ final class SMTPRequestEncoder: MessageToByteEncoder {
                 --\(mainBoundary)--\r\n
                 """
             }
-            out.write(string: "Content-type: \(contentType)\r\n")
-            out.write(string: "MIME-Version: 1.0\r\n\r\n")
-            out.write(string: bodyAndAttachments)
-            out.write(string: "\r\n.")
+            out.writeString("Content-type: \(contentType)\r\n")
+            out.writeString("MIME-Version: 1.0\r\n\r\n")
+            out.writeString(bodyAndAttachments)
+            out.writeString("\r\n.")
         case .quit:
-            out.write(string: "QUIT")
+            out.writeString("QUIT")
         }
-        out.write(string: "\r\n")
+            out.writeString("\r\n")
     }
 }

--- a/Sources/SwiftSMTP/NIO Channel Handlers/SMTPResponseDecoder.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/SMTPResponseDecoder.swift
@@ -4,7 +4,7 @@ final class SMTPResponseDecoder: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = SMTPResponse
 
-    func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+    func channelRead(context ctx: ChannelHandlerContext, data: NIOAny) {
         var response = unwrapInboundIn(data)
         guard let firstFourBytes = response.readString(length: 4), let code = Int(firstFourBytes.dropLast()) else {
             ctx.fireErrorCaught(MalformedSMTPMessageError())

--- a/Sources/SwiftSMTP/NIO Channel Handlers/StartTLSDuplexHandler.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/StartTLSDuplexHandler.swift
@@ -23,7 +23,7 @@ internal final class StartTLSDuplexHandler: ChannelDuplexHandler, RemovableChann
         self.tlsMode = tlsMode
     }
 
-    func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+    func channelRead(context ctx: ChannelHandlerContext, data: NIOAny) {
         guard case .waitingForStartTLSResponse = state else {
             ctx.fireChannelRead(data)
             return
@@ -51,7 +51,7 @@ internal final class StartTLSDuplexHandler: ChannelDuplexHandler, RemovableChann
         }
     }
 
-    func write(ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+    func write(context ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         if case .startTLS = unwrapOutboundIn(data) {
             state = .waitingForStartTLSResponse
         }

--- a/Sources/SwiftSMTP/NIO Channel Handlers/StartTLSDuplexHandler.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/StartTLSDuplexHandler.swift
@@ -1,7 +1,7 @@
 import NIO
-import NIOOpenSSL
+import NIOSSL
 
-internal final class StartTLSDuplexHandler: ChannelDuplexHandler {
+internal final class StartTLSDuplexHandler: ChannelDuplexHandler, RemovableChannelHandler {
     typealias InboundIn = SMTPResponse
     typealias InboundOut = SMTPResponse
     typealias OutboundIn = SMTPRequest
@@ -41,11 +41,11 @@ internal final class StartTLSDuplexHandler: ChannelDuplexHandler {
             return
         }
         do {
-            let sslContext = try SSLContext(configuration: .forClient())
-            let sslHandler = try OpenSSLClientHandler(context: sslContext, serverHostname: server.hostname)
-            _ = ctx.channel.pipeline.add(handler: sslHandler, first: true)
+            let sslContext = try NIOSSLContext(configuration: .forClient())
+            let sslHandler = try NIOSSLClientHandler(context: sslContext, serverHostname: server.hostname)
+            _ = ctx.channel.pipeline.addHandler(sslHandler, name: nil, position: .first)
             ctx.fireChannelRead(data)
-            _ = ctx.channel.pipeline.remove(handler: self)
+            _ = ctx.channel.pipeline.removeHandler(self)
         } catch {
             ctx.fireErrorCaught(error)
         }


### PR DESCRIPTION
Fixes changes in syntax of NIO & NIO-SSL.
Disables SwiftSMTPVapor library & tests as it seems `vapor/service` 
requires swift-nio 1.0.0..<2.0.0